### PR TITLE
Reduce connection to Redis server

### DIFF
--- a/lib/tdiary/cache/redis.rb
+++ b/lib/tdiary/cache/redis.rb
@@ -82,7 +82,7 @@ module TDiary
 		end
 
 		def redis
-			@_client ||= if @tdiary.conf.user_name
+			@@_client ||= if @tdiary.conf.user_name
 								 Redis::Namespace.new(@tdiary.conf.user_name.to_sym, redis: Redis.new)
 							 else
 								 Redis.new


### PR DESCRIPTION
redislabs.com の Redis サーバを環境変数 REDIS_URL にセットして tDiary から使ってみていたところ、
free プランでの接続上限 30 に到達して例外が発生しました。

```
Redis::CommandError
ERR max number of clients reached
/usr/local/bundle/gems/redis-3.2.1/lib/redis/client.rb:113:in `call'
/usr/local/bundle/gems/redis-3.2.1/lib/redis/client.rb:95:in `block in connect'
/usr/local/bundle/gems/redis-3.2.1/lib/redis/client.rb:279:in `with_reconnect'
/usr/local/bundle/gems/redis-3.2.1/lib/redis/client.rb:93:in `connect'
/usr/local/bundle/gems/redis-3.2.1/lib/redis/client.rb:350:in `ensure_connected'
/usr/local/bundle/gems/redis-3.2.1/lib/redis/client.rb:207:in `block in process'
/usr/local/bundle/gems/redis-3.2.1/lib/redis/client.rb:292:in `logging'
/usr/local/bundle/gems/redis-3.2.1/lib/redis/client.rb:206:in `process'
/usr/local/bundle/gems/redis-3.2.1/lib/redis/client.rb:112:in `call'
/usr/local/bundle/gems/redis-3.2.1/lib/redis.rb:789:in `block in get'
/usr/local/bundle/gems/redis-3.2.1/lib/redis.rb:37:in `block in synchronize'
/usr/local/lib/ruby/2.2.0/monitor.rb:211:in `mon_synchronize'
/usr/local/bundle/gems/redis-3.2.1/lib/redis.rb:37:in `synchronize'
/usr/local/bundle/gems/redis-3.2.1/lib/redis.rb:788:in `get'
/usr/local/bundle/bundler/gems/tdiary-cache-redis-e940dc40876c/lib/tdiary/cache/redis.rb:54:in `restore_parser_cache'
/usr/local/bundle/bundler/gems/tdiary-io-rdb-f7f7024bd042/lib/tdiary/io/rdb.rb:135:in `transaction'
/usr/src/app/lib/tdiary/view.rb:262:in `initialize'
/usr/src/app/lib/tdiary/diary_container.rb:25:in `new'
/usr/src/app/lib/tdiary/diary_container.rb:25:in `initialize'
/usr/src/app/lib/tdiary/diary_container.rb:15:in `new'
/usr/src/app/lib/tdiary/diary_container.rb:15:in `find_by_month'
(plugin/recent_list.rb):34:in `block (3 levels) in recent_list'
(plugin/recent_list.rb):33:in `reverse_each'
(plugin/recent_list.rb):33:in `block (2 levels) in recent_list'
(plugin/recent_list.rb):32:in `reverse_each'
(plugin/recent_list.rb):32:in `block in recent_list'
(plugin/recent_list.rb):31:in `catch'
(plugin/recent_list.rb):31:in `recent_list'
(TDiary::Plugin#eval_src):197:in `block in eval_src'
/usr/src/app/lib/tdiary/plugin.rb:107:in `eval'
/usr/src/app/lib/tdiary/plugin.rb:107:in `block in eval_src'
/usr/src/app/lib/tdiary/core_ext.rb:122:in `block in safe'
/usr/src/app/lib/tdiary/core_ext.rb:124:in `call'
/usr/src/app/lib/tdiary/core_ext.rb:124:in `safe'
/usr/src/app/lib/tdiary/plugin.rb:106:in `eval_src'
/usr/src/app/lib/tdiary/base.rb:66:in `do_eval_rhtml'
/usr/src/app/lib/tdiary/base.rb:30:in `eval_rhtml'
/usr/src/app/lib/tdiary/view.rb:140:in `eval_rhtml'
/usr/src/app/lib/tdiary/dispatcher/index_main.rb:38:in `run'
/usr/src/app/lib/tdiary/dispatcher/index_main.rb:6:in `run'
/usr/src/app/lib/tdiary/dispatcher.rb:26:in `dispatch_cgi'
/usr/src/app/lib/tdiary/dispatcher.rb:21:in `call'
/usr/src/app/lib/tdiary/rack/valid_request_path.rb:17:in `block in call'
/usr/src/app/lib/tdiary/rack/valid_request_path.rb:16:in `each'
/usr/src/app/lib/tdiary/rack/valid_request_path.rb:16:in `call'
/usr/src/app/lib/tdiary/rack/static.rb:15:in `call'
/usr/src/app/lib/tdiary/rack/html_anchor.rb:20:in `call'
/usr/local/bundle/gems/rack-1.6.4/lib/rack/urlmap.rb:66:in `block in call'
/usr/local/bundle/gems/rack-1.6.4/lib/rack/urlmap.rb:50:in `each'
/usr/local/bundle/gems/rack-1.6.4/lib/rack/urlmap.rb:50:in `call'
/usr/local/bundle/gems/rack-1.6.4/lib/rack/urlmap.rb:66:in `block in call'
/usr/local/bundle/gems/rack-1.6.4/lib/rack/urlmap.rb:50:in `each'
/usr/local/bundle/gems/rack-1.6.4/lib/rack/urlmap.rb:50:in `call'
/usr/src/app/lib/tdiary/application.rb:64:in `call'
/usr/local/bundle/gems/passenger-5.0.18/lib/phusion_passenger/rack/thread_handler_extension.rb:94:in `process_request'
/usr/local/bundle/gems/passenger-5.0.18/lib/phusion_passenger/request_handler/thread_handler.rb:149:in `accept_and_process_next_request'
/usr/local/bundle/gems/passenger-5.0.18/lib/phusion_passenger/request_handler/thread_handler.rb:110:in `main_loop'
/usr/local/bundle/gems/passenger-5.0.18/lib/phusion_passenger/request_handler.rb:415:in `block (3 levels) in start_threads'
/usr/local/bundle/gems/passenger-5.0.18/lib/phusion_passenger/utils.rb:112:in `block in create_thread_and_abort_on_exception'
```

以下は Rack applicationサーバとして passenger standalone を使用し、短時間で現象再現のため `ab -c 3 -n 100` でアクセス
したときの Redis の接続数のグラフです。

![image](https://cloud.githubusercontent.com/assets/162862/9911372/cb11a954-5cdc-11e5-8b9b-08898923254b.png)

Redis のオブジェクトが GC されれば接続数も減るのですが、
どうやら Redis のオブジェクトへの参照がずっと残り続けてしまうようです。
Redis#disconnect! を呼ぶ、でも良いのですが、ひとまず tdiary-io-rdb のように
クラス変数にして Redis への接続を少なくしてみました。

修正後は以下のように接続数を抑えることができています。

![image](https://cloud.githubusercontent.com/assets/162862/9911452/25558aac-5cdd-11e5-9dd5-3a8c46c30c88.png)

